### PR TITLE
Add social previews, view transitions, reading time, 404, OG images

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,11 +1,17 @@
 import { defineConfig } from "astro/config";
 import sitemap from "@astrojs/sitemap";
+import { remarkReadingTime } from "./src/lib/remark-reading-time.mjs";
 
 // https://astro.build/config
 export default defineConfig({
   site: "https://aniravi.com",
   integrations: [sitemap()],
+  prefetch: {
+    prefetchAll: true,
+    defaultStrategy: "viewport",
+  },
   markdown: {
+    remarkPlugins: [remarkReadingTime],
     shikiConfig: { theme: "github-dark" },
   },
 });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "@astrojs/rss": "4.0.18",
     "@astrojs/sitemap": "3.7.3",
-    "astro": "6.4.5"
+    "astro": "6.4.5",
+    "astro-og-canvas": "0.11.1",
+    "canvaskit-wasm": "^0.41.1"
   },
   "devDependencies": {
     "pagefind": "1.5.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       astro:
         specifier: 6.4.5
         version: 6.4.5(@types/node@24.13.1)(rollup@4.61.1)
+      astro-og-canvas:
+        specifier: 0.11.1
+        version: 0.11.1(astro@6.4.5(@types/node@24.13.1)(rollup@4.61.1))
+      canvaskit-wasm:
+        specifier: ^0.41.1
+        version: 0.41.1
     devDependencies:
       pagefind:
         specifier: 1.5.2
@@ -640,6 +646,9 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
+  '@webgpu/types@0.1.21':
+    resolution: {integrity: sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -657,6 +666,11 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
+  astro-og-canvas@0.11.1:
+    resolution: {integrity: sha512-6omy7MJeOPwxdYH5+eL3zFIY9MhuDRUMuASuCx/eXNrHGUogq9ZHdx19A428KtWhLVuXVcLt7Klw5fxqASAHmg==}
+    peerDependencies:
+      astro: ^5.0.0 || ^6.0.0-alpha
+
   astro@6.4.5:
     resolution: {integrity: sha512-0R7WLD1+WD/mTPcZxyKtcF0CztQi9ahFRtGM7oChJhxjNbr4lSBenxi+mk91k5bPTaUEoZ6edg1fDo2qP8bCwg==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
@@ -669,8 +683,14 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  base-64@1.0.0:
+    resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  canvaskit-wasm@0.41.1:
+    resolution: {integrity: sha512-gO2rNMIE0lOQ8MaarM4qNeq2zZAEknAObKP2XAKidMSAY8P5sURGdFkrx1TSdHuBFqTf5w35JqjuUzjibqkD5g==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -762,6 +782,10 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  deterministic-object-hash@2.0.2:
+    resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
+    engines: {node: '>=18'}
+
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
@@ -796,6 +820,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -1970,6 +1998,8 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
+  '@webgpu/types@0.1.21': {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -1982,6 +2012,13 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  astro-og-canvas@0.11.1(astro@6.4.5(@types/node@24.13.1)(rollup@4.61.1)):
+    dependencies:
+      astro: 6.4.5(@types/node@24.13.1)(rollup@4.61.1)
+      canvaskit-wasm: 0.41.1
+      deterministic-object-hash: 2.0.2
+      entities: 8.0.0
 
   astro@6.4.5(@types/node@24.13.1)(rollup@4.61.1):
     dependencies:
@@ -2080,7 +2117,13 @@ snapshots:
 
   bail@2.0.2: {}
 
+  base-64@1.0.0: {}
+
   boolbase@1.0.0: {}
+
+  canvaskit-wasm@0.41.1:
+    dependencies:
+      '@webgpu/types': 0.1.21
 
   ccount@2.0.1: {}
 
@@ -2153,6 +2196,10 @@ snapshots:
   detect-libc@2.1.2:
     optional: true
 
+  deterministic-object-hash@2.0.2:
+    dependencies:
+      base-64: 1.0.0
+
   devalue@5.8.1: {}
 
   devlop@1.1.0:
@@ -2184,6 +2231,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@8.0.0: {}
 
   es-module-lexer@2.1.0: {}
 

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -15,12 +15,18 @@
 </style>
 
 <script is:inline>
-  document.getElementById("theme-toggle")?.addEventListener("click", () => {
-    const root = document.documentElement;
-    root.classList.toggle("dark");
-    localStorage.setItem(
-      "theme",
-      root.classList.contains("dark") ? "dark" : "light",
-    );
-  });
+  // Delegated so it keeps working across view transitions (the button
+  // element is replaced on navigation, but document persists).
+  if (!window.__themeToggleBound) {
+    window.__themeToggleBound = true;
+    document.addEventListener("click", (e) => {
+      if (!e.target.closest("#theme-toggle")) return;
+      const root = document.documentElement;
+      root.classList.toggle("dark");
+      localStorage.setItem(
+        "theme",
+        root.classList.contains("dark") ? "dark" : "light",
+      );
+    });
+  }
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from "astro:transitions";
 import Nav from "../components/Nav.astro";
 import Footer from "../components/Footer.astro";
 import "../styles/global.css";
@@ -6,10 +7,20 @@ import "../styles/global.css";
 interface Props {
   title?: string;
   description?: string;
+  image?: string; // OG image path, relative to the site root
+  type?: "website" | "article";
 }
 
-const { title, description = "Ani Ravi's personal website" } = Astro.props;
+const {
+  title,
+  description = "Ani Ravi's personal website",
+  image = "/og/default.png",
+  type = "website",
+} = Astro.props;
+
 const fullTitle = title ? `${title} – Ani Ravi` : "Ani Ravi";
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const ogImage = new URL(image, Astro.site);
 
 // Pagefind only exists after `pagefind --site dist` runs, i.e. in the
 // production build. Skipping it in dev avoids 404s on the search assets.
@@ -25,6 +36,19 @@ const isProd = import.meta.env.PROD;
     <meta name="robots" content="index, follow" />
     <title>{fullTitle}</title>
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalURL} />
+
+    <!-- Open Graph / Twitter social previews -->
+    <meta property="og:type" content={type} />
+    <meta property="og:title" content={fullTitle} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:image" content={ogImage} />
+    <meta property="og:site_name" content="Ani Ravi" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={fullTitle} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImage} />
 
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
@@ -41,13 +65,19 @@ const isProd = import.meta.env.PROD;
     <link rel="sitemap" href="/sitemap-index.xml" />
     {isProd && <link href="/pagefind/pagefind-ui.css" rel="stylesheet" />}
 
-    <!-- Set theme before paint to avoid a flash -->
+    <ClientRouter />
+
+    <!-- Set theme before paint, and re-apply after each view transition -->
     <script is:inline>
-      const stored = localStorage.getItem("theme");
-      const dark =
-        stored === "dark" ||
-        (!stored && matchMedia("(prefers-color-scheme: dark)").matches);
-      if (dark) document.documentElement.classList.add("dark");
+      const setTheme = () => {
+        const stored = localStorage.getItem("theme");
+        const dark =
+          stored === "dark" ||
+          (!stored && matchMedia("(prefers-color-scheme: dark)").matches);
+        document.documentElement.classList.toggle("dark", dark);
+      };
+      setTheme();
+      document.addEventListener("astro:after-swap", setTheme);
     </script>
   </head>
   <body>
@@ -65,13 +95,19 @@ const isProd = import.meta.env.PROD;
         <>
           <script is:inline src="/pagefind/pagefind-ui.js" />
           <script is:inline>
-            window.addEventListener("DOMContentLoaded", () => {
-              new PagefindUI({
-                element: "#search",
-                showSubResults: true,
-                showImages: false,
-              });
-            });
+            const initSearch = () => {
+              const el = document.querySelector("#search");
+              if (el && window.PagefindUI && !el.dataset.ready) {
+                el.dataset.ready = "1";
+                new PagefindUI({
+                  element: "#search",
+                  showSubResults: true,
+                  showImages: false,
+                });
+              }
+            };
+            // Run on first load and after each view transition.
+            document.addEventListener("astro:page-load", initSearch);
           </script>
         </>
       )

--- a/src/lib/remark-reading-time.mjs
+++ b/src/lib/remark-reading-time.mjs
@@ -1,0 +1,16 @@
+// Zero-dependency reading-time estimate, injected into each post's frontmatter
+// at build time. Read it back via `remarkPluginFrontmatter.minutesRead`.
+export function remarkReadingTime() {
+  return (tree, file) => {
+    let words = 0;
+    const walk = (node) => {
+      if (typeof node.value === "string") {
+        words += node.value.split(/\s+/).filter(Boolean).length;
+      }
+      if (node.children) node.children.forEach(walk);
+    };
+    walk(tree);
+    const minutes = Math.max(1, Math.round(words / 200));
+    file.data.astro.frontmatter.minutesRead = `${minutes} min read`;
+  };
+}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,14 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="Page not found">
+  <article>
+    <h1>404 — Page not found</h1>
+    <p>That page doesn't exist (or moved). A few ways back:</p>
+    <ul>
+      <li><a href="/">Home</a></li>
+      <li><a href="/posts">All posts</a></li>
+    </ul>
+  </article>
+</BaseLayout>

--- a/src/pages/og/[...route].ts
+++ b/src/pages/og/[...route].ts
@@ -1,0 +1,30 @@
+import { getCollection } from "astro:content";
+import { OGImageRoute } from "astro-og-canvas";
+
+// Build-time OG images: one PNG per post plus a site default.
+const posts = await getCollection("blog");
+
+const pages: Record<string, { title: string; description: string }> = {
+  default: { title: "Ani Ravi", description: "Ani Ravi's personal website" },
+};
+for (const post of posts) {
+  pages[post.id] = {
+    title: post.data.title,
+    description: post.data.description ?? "",
+  };
+}
+
+export const { getStaticPaths, GET } = await OGImageRoute({
+  param: "route",
+  pages,
+  getImageOptions: (_path, page) => ({
+    title: page.title,
+    description: page.description,
+    bgGradient: [
+      [17, 17, 17],
+      [30, 30, 30],
+    ],
+    border: { color: [37, 99, 235], width: 16, side: "inline-start" },
+    padding: 60,
+  }),
+});

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -11,19 +11,26 @@ export async function getStaticPaths() {
 }
 
 const { post } = Astro.props;
-const { Content } = await render(post);
+const { Content, remarkPluginFrontmatter } = await render(post);
 const formatted = post.data.date.toLocaleDateString("en-US", {
   day: "2-digit",
   year: "numeric",
   month: "short",
 });
+const readingTime = remarkPluginFrontmatter.minutesRead;
 ---
 
-<BaseLayout title={post.data.title} description={post.data.description}>
+<BaseLayout
+  title={post.data.title}
+  description={post.data.description}
+  image={`/og/${post.id}.png`}
+  type="article"
+>
   <article data-pagefind-body>
     <h1>{post.data.title}</h1>
     <p class="meta">
       <time datetime={post.data.date.toISOString()}>{formatted}</time>
+      {readingTime && <> · {readingTime}</>}
       {post.data.author && <> · {post.data.author}</>}
       {
         post.data.tags.length > 0 && (


### PR DESCRIPTION
A polish pass — all static / build-time, fully GitHub Pages compatible (nothing needs a server).

- **Social link previews** — Open Graph + Twitter-card meta + canonical URLs on every page, so shared links render rich previews
- **Per-post OG images** — generated at build time via `astro-og-canvas` (title + description card), with a site default for non-post pages
- **Instant navigation** — `<ClientRouter>` view transitions + `prefetch` (theme, search, and the dark-mode toggle all re-bind correctly across transitions)
- **Reading time** — "N min read" on posts via a zero-dependency remark plugin
- **Custom 404** — `src/pages/404.astro`; GitHub Pages auto-serves `dist/404.html`

**Not** included: drafts-on-GitHub (explicitly declined).

Verified locally: `pnpm build` → 18 OG images, all meta tags present, Pagefind index intact, 404 + sitemap emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)