### PR TITLE
Clean up pnpm config: pin canvaskit-wasm, drop minimumReleaseAgeExclude

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@astrojs/sitemap": "3.7.3",
     "astro": "6.4.5",
     "astro-og-canvas": "0.11.1",
-    "canvaskit-wasm": "^0.41.1"
+    "canvaskit-wasm": "0.41.1"
   },
   "devDependencies": {
     "pagefind": "1.5.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: 0.11.1
         version: 0.11.1(astro@6.4.5(@types/node@24.13.1)(rollup@4.61.1))
       canvaskit-wasm:
-        specifier: ^0.41.1
+        specifier: 0.41.1
         version: 0.41.1
     devDependencies:
       pagefind:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
 allowBuilds:
   sharp: true
   esbuild: true
-minimumReleaseAgeExclude:
-  - astro@6.4.5


### PR DESCRIPTION
- Pin `canvaskit-wasm` to exact `0.41.1` to match every other dep (was a caret range pnpm added).
- Remove the auto-generated `minimumReleaseAgeExclude` cruft from `pnpm-workspace.yaml`.

Verified: `pnpm install` doesn't re-add the exclude; `pnpm build` green (18 OG images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)