### PR TITLE
ci: gate PRs on lint and format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,11 @@ jobs:
       - name: Install deps
         run: pnpm install
 
+      - name: Lint
+        run: pnpm lint
+
+      - name: Check formatting
+        run: pnpm format:check
+
       - name: Generate blog
         run: pnpm build


### PR DESCRIPTION
Adds `pnpm lint` (oxlint) and `pnpm format:check` (oxfmt) to the build job, so they run on every PR and **block merge on failure** — part of the existing required `build` check, not optional local scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)